### PR TITLE
Support npm listPackagePaths on windows

### DIFF
--- a/src/utils/npm.ts
+++ b/src/utils/npm.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process'
 
 
-const RE_NODE_MODULES = /\/node_modules\//g
+const RE_NODE_MODULES = /[\/\\]node_modules[\/\\]/g;
 
 export interface ListPackagesOptions {
   cwd?: string


### PR DESCRIPTION
Adjust the regex to allow distize to copy node_modules on windows as well